### PR TITLE
Fix `Color` tag crashing Wox

### DIFF
--- a/Dracula.xaml
+++ b/Dracula.xaml
@@ -24,7 +24,7 @@
     <Style x:Key="ItemSubTitleSelectedStyle" BasedOn="{StaticResource BaseItemSubTitleSelectedStyle}" TargetType="{x:Type TextBlock}">
         <Setter Property="Foreground" Value="#bd93f9" />
     </Style>
-    <Color x:Key="ItemSelectedBackgroundColor">#44475A</Color>
+    <SolidColorBrush x:Key="ItemSelectedBackgroundColor">#44475A</SolidColorBrush>
     <Style x:Key="ThumbStyle" BasedOn="{StaticResource BaseThumbStyle}" TargetType="{x:Type Thumb}">
       <Setter Property="Template">
           <Setter.Value>


### PR DESCRIPTION
Not certain when it stopped working, but as of 2017-07-04, the `Color` tag on line 27 crashes Wox entirely. Following the theme builder at http://www.getwox.com/theme/builder, I recreated the theme (sans scroll thumb style) and then noticed that the only significant difference was using `SolidColorBrush` instead, so I propose this fix.